### PR TITLE
feat(Makefile): add run.artifact target to execute Java application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PYTHON := python3
 VENV := .venv
 BIN := $(VENV)/bin
 
+# Java artifact variables
+ARTIFACT_PATH ?= playground/out
+
 # Install development dependencies (use this for development)
 install.dev:
 	uv venv
@@ -71,6 +74,10 @@ build: clean
 
 # Run all quality checks
 check: clean lint test
+
+# Run the generated Java application
+run.artifact:
+	cd $(ARTIFACT_PATH) && mvn spring-boot:run
 
 # Default target
 all: clean install.dev lint test 

--- a/qi/cli.py
+++ b/qi/cli.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
 from .config import Config
+from .converter import OpenAPIConverter
 from .generator import OpenAPIGenerator
 from .linter import DEFAULT_RULES, lint_specs
 from .rules import load_custom_rules
@@ -147,14 +148,13 @@ def convert(
 ):
     """Convert OpenAPI specification between versions 2 and 3."""
     try:
-        with console.status("[bold green]Loading configuration...") as status:
-            config_obj = Config.load(str(config)) if config else Config.default()
-            generator = OpenAPIGenerator(config_obj)
-            status.update("[bold green]Configuration loaded successfully!")
+        with console.status("[bold green]Initializing converter...") as status:
+            converter = OpenAPIConverter()
+            status.update("[bold green]Converter initialized successfully!")
 
         with create_progress() as progress:
             convert_task = progress.add_task("[cyan]Converting specification...", total=None)
-            output_file = generator.convert_spec_version(
+            output_file = converter.convert_spec_version(
                 str(spec_file),
                 target_version,
                 str(output) if output else None,

--- a/qi/converter.py
+++ b/qi/converter.py
@@ -91,3 +91,15 @@ class OpenAPIConverter:
             progress.update(task_id, description="[green]Conversion completed!")
 
         return output_file
+
+    def convert_spec_version(
+        self,
+        spec_file: str,
+        target_version: Literal["2", "3"],
+        output_file: str | None = None,
+        progress: Progress | None = None,
+        task_id: TaskID | None = None,
+    ) -> str:
+        """Convert OpenAPI specification between versions 2 and 3."""
+        result = self.convert_spec(spec_file, target_version, output_file, progress, task_id)
+        return str(result)

--- a/qi/generator.py
+++ b/qi/generator.py
@@ -2,14 +2,13 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
 import requests
 import yaml
 from rich.progress import Progress, TaskID
 
 from .config import Config
-from .converter import OpenAPIConverter
 
 
 @dataclass
@@ -29,7 +28,6 @@ class OpenAPIGenerator:
     def __init__(self, config: Config):
         self.config = config
         self.tracking_data = self._load_tracking()
-        self.converter = OpenAPIConverter()
 
     def _load_tracking(self) -> dict[str, str]:
         """Load tracking data from file."""
@@ -245,15 +243,3 @@ class OpenAPIGenerator:
                 config.progress.update(config.task_id, description=f"[yellow]Moving {file_name} to default location")
                 shutil.copy2(source_path, target_path)
                 self.tracking_data[model_name] = target_path
-
-    def convert_spec_version(
-        self,
-        spec_file: str,
-        target_version: Literal["2", "3"],
-        output_file: str | None = None,
-        progress: Progress | None = None,
-        task_id: TaskID | None = None,
-    ) -> str:
-        """Convert OpenAPI specification between versions 2 and 3."""
-        result = self.converter.convert_spec(spec_file, target_version, output_file, progress, task_id)
-        return str(result)


### PR DESCRIPTION
refactor(cli.py): use OpenAPIConverter directly for spec conversion

refactor(generator.py): remove convert_spec_version method

test(cli.py): update tests to mock OpenAPIConverter instead of OpenAPIGenerator